### PR TITLE
[wip] initial commit to implement payment simulation on LN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+__pycache__
+pickhardtpayments/pickhardtpayments.egg-info

--- a/examples/simulationexample.py
+++ b/examples/simulationexample.py
@@ -1,0 +1,49 @@
+sys.path.append(r'../pickhardtpayments')
+from pickhardtpayments.ChannelGraph import ChannelGraph
+from pickhardtpayments.UncertaintyNetwork import UncertaintyNetwork
+from pickhardtpayments.OracleLightningNetwork import OracleLightningNetwork
+from pickhardtpayments.SyncSimulatedPaymentSession import SyncSimulatedPaymentSession
+
+
+#we first need to import the chanenl graph from c-lightning jsondump
+#you can get your own data set via:
+# $: lightning-cli listchannels > listchannels20220412.json
+# alternatively you can go to https://ln.rene-pickhardt.de to find a data dump
+channel_graph = ChannelGraph("listchannels20220412.json")
+
+uncertainty_network = UncertaintyNetwork(channel_graph)
+oracle_lightning_network = OracleLightningNetwork(channel_graph)
+#we create ourselves a payment session which in this case operates by sending out the onions
+#sequentially
+payment_session = SyncSimulatedPaymentSession(oracle_lightning_network,
+                                 uncertainty_network,
+                                 prune_network=False)
+
+#we need to make sure we forget all learnt information on the Uncertainty Nework
+payment_session.forget_information()
+
+#we run the simulation of pickhardt payments and track all the results
+
+exit(0)
+
+#
+# Simulation part will follow here.
+#
+# n times:
+#   "randomly" select paying node
+#   "randomly" select receiving node
+#   decide on payment_amount
+#   pay! (not just send onion)
+#   update OracleLightningNetwork
+#
+# observe and analyse
+
+
+#Rene Pickhardt's public node key
+RENE = "03efccf2c383d7bf340da9a3f02e2c23104a0e4fe8ac1a880c8e2dc92fbdacd9df"
+#Carsten Otto's public node key
+C_OTTO = "027ce055380348d7812d2ae7745701c9f93e70c1adeb2657f053f91df4f2843c71"
+tested_amount = 10_000_000 #10 million sats
+
+payment_session.pickhardt_pay(RENE,C_OTTO, tested_amount,mu=0,base=0)
+


### PR DESCRIPTION
Template to include the simulation of payments on the ChannelGraph, extending the previous single period model to a multi period model.

Not included is the Channel Graph "listchannels20220412.json", residing in repo root.