### PR TITLE
Fix typos in documentation

### DIFF
--- a/examples/PickhardtPaymentsExample.ipynb
+++ b/examples/PickhardtPaymentsExample.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Example code demonstrating how to use the `pickhardtpayments` package in python. You need to install the library via `pip install pickhardtpayments` or you can download the full source code at https://ln.rene-pickhardt.de or a copy from github at: https://www.github.com/renepickhardt/pickhardtpayments\n",
     "\n",
-    "Of course you can use the classes int the library to create your own async payment loop or you could exchange the Oracle to talk to the actual Lightning network by wrapping against your favourite node implementation and exposing the the `send_onion` call. \n",
+    "Of course you can use the classes in the library to create your own async payment loop or you could exchange the Oracle to talk to the actual Lightning network by wrapping against your favourite node implementation and exposing the the `send_onion` call. \n",
     "\n",
     "This example assumes a randomly generated Oracle to conduct payments in a simulated way. For this you will need an actual channelgraph which you can get for example with `lightning-cli listchannels > listchannels20220412.json`\n",
     "\n",
@@ -39,14 +39,14 @@
     "#Carsten Otto's public node key\n",
     "C_OTTO = \"027ce055380348d7812d2ae7745701c9f93e70c1adeb2657f053f91df4f2843c71\"\n",
     "\n",
-    "#we first need to import the chanenl graph from c-lightning jsondump\n",
+    "#we first need to import the chanenl graph from core lightning jsondump\n",
     "#you can get your own data set via:\n",
     "# $: lightning-cli listchannels > listchannels20220412.json\n",
     "# alternatively you can go to https://ln.rene-pickhardt.de to find a data dump\n",
     "channel_graph = ChannelGraph(\"listchannels20220412.json\")\n",
     "\n",
-    "#we now create ourself an Oracle. This is Simulated Network that assumes unformly distribution \n",
-    "#of the liquidity for the channels on the `channel_graph`. Of course one could create ones own \n",
+    "#we now create an Oracle. This is a Simulated Network that assumes uniform distribution \n",
+    "#of the liquidity for the channels on the `channel_graph`. Of course one could create one's own \n",
     "#oracle (for example a wrapper to an existing lightning network node / implementation)\n",
     "oracle_lightning_network = OracleLightningNetwork(channel_graph)"
    ]
@@ -66,7 +66,7 @@
    ],
    "source": [
     "# Since we randomly generated our Oracle but also since we control it we can compute\n",
-    "# The maximum possible amout that can be payed between two nodes\n",
+    "# The maximum possible amount that can be payed between two nodes\n",
     "maximum_payable_amount =oracle_lightning_network.theoretical_maximum_payable_amount(RENE,C_OTTO,1000)\n",
     "print(maximum_payable_amount, \"sats would be possible on this oracle to deliver if including 1 sat basefee channels\")\n"
    ]
@@ -86,7 +86,7 @@
    ],
    "source": [
     "#Of course we want to restrict ourselves to the zeroBaseFee part of the network.\n",
-    "#Therefor we compute the theoretical maximum payable amount for that subgraph\n",
+    "#Therefore we compute the theoretical maximum payable amount for that subgraph\n",
     "maximum_payable_amount =oracle_lightning_network.theoretical_maximum_payable_amount(RENE,C_OTTO,0)\n",
     "print(maximum_payable_amount, \"sats possible on this oracle on the zeroBaseFeeGraph\")"
    ]
@@ -307,16 +307,16 @@
     }
    ],
    "source": [
-    "# We chose an amount that is 50% of half the theoretic maximum to demonstrate the the\n",
+    "# We choose an amount that is half the theoretical maximum to demonstrate the\n",
     "# minimum cost flow solver with Bayesian updates on the Uncertainty Network finds the\n",
     "# liquidity rather quickly\n",
     "tested_amount = int(maximum_payable_amount/2)\n",
     "\n",
-    "# From the channel graph we can derrive our initial Uncertainty Network which is the main data structure\n",
+    "# From the channel graph we can derive our initial Uncertainty Network which is the main data structure\n",
     "# that we maintain in order to deliver sats from one node to another\n",
     "uncertainty_network = UncertaintyNetwork(channel_graph)\n",
     "\n",
-    "#we create ourselves a payment session which in this case operates by sending out the onions\n",
+    "#we create a payment session which in this case operates by sending out the onions\n",
     "#sequentially \n",
     "payment_session = SyncSimulatedPaymentSession(oracle_lightning_network, \n",
     "                                 uncertainty_network,\n",
@@ -335,7 +335,7 @@
    "source": [
     "## Optimizing for Fees\n",
     "\n",
-    "controlling mu we can decide how much we wish to focuse on lower fees. However we will see that it will be much harder to deliver the same amount in the sense that we need to send out more onions and also have more failed attampts. Consiquantly we expect to need more time."
+    "controlling mu we can decide how much we wish to focus on lower fees. However ,we will see that it will be much harder to deliver the same amount in the sense that we need to send out more onions and also have more failed attampts. Consequently we expect to need more time."
    ]
   },
   {

--- a/examples/basicexample.py
+++ b/examples/basicexample.py
@@ -4,7 +4,7 @@ from pickhardtpayments.OracleLightningNetwork import OracleLightningNetwork
 from pickhardtpayments.SyncSimulatedPaymentSession import SyncSimulatedPaymentSession
 
 
-#we first need to import the chanenl graph from c-lightning jsondump
+#we first need to import the channel graph from core lightning jsondump
 #you can get your own data set via:
 # $: lightning-cli listchannels > listchannels20220412.json
 # alternatively you can go to https://ln.rene-pickhardt.de to find a data dump
@@ -12,7 +12,7 @@ channel_graph = ChannelGraph("listchannels20220412.json")
 
 uncertainty_network = UncertaintyNetwork(channel_graph)
 oracle_lightning_network = OracleLightningNetwork(channel_graph)
-#we create ourselves a payment session which in this case operates by sending out the onions
+#we create a payment session which in this case operates by sending out the onions
 #sequentially 
 payment_session = SyncSimulatedPaymentSession(oracle_lightning_network, 
                                  uncertainty_network,

--- a/pickhardtpayments/Channel.py
+++ b/pickhardtpayments/Channel.py
@@ -1,7 +1,7 @@
 class ChannelFields():
     """
     These are the values describing public data about channels that is either available
-    via gossip or via the Bitcoin Blockchain. Their format is taken from the c-lighting
+    via gossip or via the Bitcoin Blockchain. Their format is taken from the core lighting
     API. If you use a different implementation I suggest to write a wrapper around the
     `ChannelFields` and `Channel` class
     """
@@ -25,8 +25,8 @@ class Channel():
     """
     Stores the public available information of a channel.
 
-    The `Channel` Class is intended to be read only and internatlly stores
-    the data from c-lightning's `lightning-cli listchannels` command as a json.
+    The `Channel` Class is intended to be read only and internally stores
+    the data from core lightning's `lightning-cli listchannels` command as a json.
     If you retrieve data from a different implementation I suggest to overload
     the constructor and transform the information into the given json format
     """

--- a/pickhardtpayments/ChannelGraph.py
+++ b/pickhardtpayments/ChannelGraph.py
@@ -8,7 +8,7 @@ class ChannelGraph():
     Represents the public information about the Lightning Network that we see from Gossip and the 
     Bitcoin Blockchain. 
 
-    The channels of the Channel Graph are directed and identiried uniquly by a triple consisting of
+    The channels of the Channel Graph are directed and identified uniquely by a triple consisting of
     (source_node_id, destination_node_id, short_channel_id). This allows the ChannelGraph to also 
     contain parallel channels.
     """
@@ -22,7 +22,7 @@ class ChannelGraph():
 
     def __init__(self, lightning_cli_listchannels_json_file: str):
         """
-        Importing the channel_graph from c-lightning listchannels command the file can be received by 
+        Importing the channel_graph from core lightning listchannels command the file can be received by 
         #$ lightning-cli listchannels > listchannels.json
 
         """

--- a/pickhardtpayments/OracleChannel.py
+++ b/pickhardtpayments/OracleChannel.py
@@ -5,7 +5,7 @@ import random
 
 class OracleChannel(Channel):
     """
-    An OracleChannel us used in experiments and Simulations to form the (Oracle)LightningNetwork.
+    An OracleChannel is used in experiments and Simulations to form the (Oracle)LightningNetwork.
 
     It contains a ground truth about the Liquidity of a channel
     """
@@ -24,8 +24,8 @@ class OracleChannel(Channel):
         """
         Tells us the actual liquidity according to the oracle. 
 
-        This is usful for experiments but must of course not be used in routing and is also
-        not a vailable if mainnet remote channels are being used.
+        This is useful for experiments but must of course not be used in routing and is also
+        not available if mainnet remote channels are being used.
         """
         return self._actual_liquidity
 

--- a/pickhardtpayments/SyncSimulatedPaymentSession.py
+++ b/pickhardtpayments/SyncSimulatedPaymentSession.py
@@ -19,8 +19,8 @@ class SyncSimulatedPaymentSession():
     This happens by adding several parallel arcs coming from the piece wise linearization of the
     UncertaintyChannel to the min_cost_flow object. 
 
-    The main API call ist `pickhardt_pay` which invokes a sequential loop to conduct trial and error
-    attmpts. The loop could easily send out all onions concurrently but this does not make sense 
+    The main API call is `pickhardt_pay` which invokes a sequential loop to conduct trial and error
+    attempts. The loop could easily send out all onions concurrently but this does not make sense 
     against the simulated OracleLightningNetwork. 
     """
 
@@ -96,7 +96,7 @@ class SyncSimulatedPaymentSession():
 
     def _next_hop(self, path):
         """
-        generator to iterate through edges indext by node id of paths
+        generator to iterate through edges indexed by node id of paths
 
         The path is a list of node ids. Each call returns a tuple src, dest of an edge in the path    
         """
@@ -133,9 +133,9 @@ class SyncSimulatedPaymentSession():
         """
         A standard algorithm to disect a flow into several paths.
 
-        FIXME: Note that this disection while accurate is probably not optimal in practise. 
+        FIXME: Note that this dissection while accurate is probably not optimal in practice. 
         As noted in our Probabilistic payment delivery paper the payment process is a bernoulli trial 
-        and I assume it makes sense to disect the flow into paths of similar likelihood to make most
+        and I assume it makes sense to dissect the flow into paths of similar likelihood to make most
         progress but this is a mere conjecture at this point. I expect quite a bit of research will be
         necessary to resolve this issue.
         """
@@ -186,7 +186,7 @@ class SyncSimulatedPaymentSession():
 
         This is one step within the payment loop.
 
-        Retuns the residual amount of the `amt` that could ne be delivered and the paid fees
+        Returns the residual amount of the `amt` that could ne be delivered and the paid fees
         (on a per channel base not including fees for downstream fees) for the delivered amount
 
         the function also prints some results an statistics about the paths of the flow to stdout.

--- a/pickhardtpayments/UncertaintyChannel.py
+++ b/pickhardtpayments/UncertaintyChannel.py
@@ -13,9 +13,9 @@ class UncertaintyChannel(Channel):
     UncertaintyNetwork.
 
     Since we optimize for reliability via a probability estimate for liquidity that is based
-    on the capacity of the channel the class contains the `capacity` as seen in the funding tx output.
+    on the capacity of the channel, the class contains the `capacity` as seen in the funding tx output.
 
-    As we also optimize for fees and want to be able to compute the fees of a flow the classe
+    As we also optimize for fees and want to be able to compute the fees of a flow ,the class
     contains information for the feerate (`ppm`) and the base_fee (`base`). 
 
     Most importantly the class stores our belief about the liquidity information of a channel.
@@ -91,7 +91,7 @@ class UncertaintyChannel(Channel):
     # FIXME: store timestamps when using setters so that we know when we learnt our belief
     def forget_information(self):
         """
-        resets the information that we belief to have about the channel. 
+        resets the information that we believe to have about the channel. 
         """
         self.min_liquidity = 0
         self.max_liquidity = self.capacity

--- a/pickhardtpayments/UncertaintyNetwork.py
+++ b/pickhardtpayments/UncertaintyNetwork.py
@@ -67,7 +67,7 @@ class UncertaintyNetwork(ChannelGraph):
 
     def activate_network_wide_uncertainty_reduction(self, n, oracle: OracleLightningNetwork):
         """
-        With the help of an `OracleLightningNetwork` probes all chennels `n` times to reduce uncertainty.
+        With the help of an `OracleLightningNetwork` probes all channels `n` times to reduce uncertainty.
 
         While one can do this on mainnet by probing we can do this very quickly in simulation
         at virtually no cost. Thus this API call needs to be taken with caution when using a different

--- a/readme.md
+++ b/readme.md
@@ -4,9 +4,9 @@ The `pickhardtpayments` package is a collection of classes and interfaces that h
 
 ## What are Pickhardt Payments?
 
-Pickhardt Payments are the method of deliverying satoshis from on Lightning network Node to another by using [probabilistic payment delivery](https://arxiv.org/abs/2103.08576) in a round based `payment loop` that updeates our `belief` of the remote `liquidity` in the `Uncertainty Network` and generates [optimally reliable and cheap payment flows](https://arxiv.org/abs/2107.05322) in every round by solving a [piece wise linearized min integer cost flow problem](https://github.com/renepickhardt/mpp-splitter/blob/pickhardt-payments-simulation-dev/Minimal%20Linearized%20min%20cost%20flow%20example%20for%20MPP.ipynb) with a seperable cost function.
+Pickhardt Payments are the method of deliverying satoshis from one Lightning network Node to another by using [probabilistic payment delivery](https://arxiv.org/abs/2103.08576) in a round based `payment loop` that updates our `belief` of the remote `liquidity` in the `Uncertainty Network` and generates [optimally reliable and cheap payment flows](https://arxiv.org/abs/2107.05322) in every round by solving a [piece wise linearized min integer cost flow problem](https://github.com/renepickhardt/mpp-splitter/blob/pickhardt-payments-simulation-dev/Minimal%20Linearized%20min%20cost%20flow%20example%20for%20MPP.ipynb) with a separable cost function.
 
-As of now the two main features of the cost function are the `linearized_uncertainty_unit_cost` (effectively proportional to `1/channel_capacity`) and the `linearized_routing_unit_cost` (effectivly just the `ppm`).
+As of now the two main features of the cost function are the `linearized_uncertainty_unit_cost` (effectively proportional to `1/channel_capacity`) and the `linearized_routing_unit_cost` (effectively just the `ppm`).
 
 ## Depenencies
 
@@ -20,7 +20,7 @@ The dependencies can be found at:
 
 ## build and install
 
-Onestep install is via pip by typing `pip install pickhardtpayments` to your command line
+One step install is via pip by typing `pip install pickhardtpayments` to your command line
 
 If you want to build and install the library yourself you can do:
 
@@ -43,7 +43,7 @@ from pickhardtpayments.OracleLightningNetwork import OracleLightningNetwork
 from pickhardtpayments.SyncSimulatedPaymentSession import SyncSimulatedPaymentSession
 
 
-#we first need to import the chanenl graph from c-lightning jsondump
+#we first need to import the chanenl graph from core lightning jsondump
 #you can get your own data set via:
 # $: lightning-cli listchannels > listchannels20220412.json
 # alternatively you can go to https://ln.rene-pickhardt.de to find a data dump
@@ -51,7 +51,7 @@ channel_graph = ChannelGraph("listchannels20220412.json")
 
 uncertainty_network = UncertaintyNetwork(channel_graph)
 oracle_lightning_network = OracleLightningNetwork(channel_graph)
-#we create ourselves a payment session which in this case operates by sending out the onions
+#we create a payment session which in this case operates by sending out the onions
 #sequentially 
 payment_session = SyncSimulatedPaymentSession(oracle_lightning_network, 
                                  uncertainty_network,


### PR DESCRIPTION
As people get familiar with Pickhardt Payments and how they work, it should be easier for them to follow along when they come across this repo. Hence,I thought it necessary to clear up some grammatical issues in the documentation. 