### PR TITLE
Proof of Concept implementation of the Dijkstra Overpayment MPP Splitter

### DIFF
--- a/pickhardtpayments/DijkstraOverPayment.py
+++ b/pickhardtpayments/DijkstraOverPayment.py
@@ -1,0 +1,214 @@
+"""
+WARNING!!! very experimental work in progress! Only use with caution and wait for the proper release
+
+The DijkstraOverPayment class aims to find Dijkstra paths in a pragmatic way for redundant overpayments. 
+In particular it is a proof of concept to generate an MPP-Split in an ad hoc way that seems to be more 
+resonable than existing splitters which either do devide an conquorer or split to a certain amount or split
+to a predefined number of parts. 
+This splitter finds low cost paths and greedly allocates as many sats as long as the reliability stays abvove a threshold
+
+The main ideas are the following: 
+
+## With respect to the cost function for candidate selection:
+
+We use dijkstra to compute candidate paths as shortest paths with respect to our cost function
+
+1.) Use a cost function for a unit that is the combination of linearized routing and linearized uncertainty cost
+2.) smooth the routing cost (currently lapalace smoothing with +100 exact value needs to be found
+3.) cost = (ppm + 100) * 1/capacity
+4.) after a path is planned increase cost of each edge with a multiplier
+
+## with respect to allocation of funds to paths
+
+The cost function favors paths with low routing costs thus the only question is how many sats to allocate? 
+The following idea shall be used for motivation: 
+
+* We want each path to have a success probability of at least x%
+* Thus let `l` be the length of the planned path and `c` be the capacity of the smallest channel.
+* Then `s = (c+1-a)/(c+1)` is the success probability for the allocated amount `a` 
+* We require `s >= x ** (1/l)` which means the path has a probability of at least `x`
+* For now we ignore prior knowledge and believe (Thus one reason for this to be WIP)
+* knowing `s` at equality we solve for `a` --> a = (c+1) - s*(c+1) = (c+1)*(1-s)
+* we allocate `a` sats to the candidate path
+
+## Number of generated / planned candidate paths
+
+* for each path we compute it's expected value of delivered sats as its actual success probability mutitplied by the allocated sats
+* As the expected value is linear we generate paths until the sum of the EVs is larger than our target total EV
+* the target total EV is the amount we wish to deliver (e.g. given by an invoice) multiplied with a reliability factor (>= 1.0)
+
+
+## known short commings:
+* subset of generated paths does not add to payment amount
+* base fee is ignored
+* learnt knowledge is ignored
+* magic numbers are hard coded and not configureable (requires refactoring of the lib)
+* output / api fits more to MCF approach
+* handeling of edge cases
+* assumes uniform distribution (which is actually easily fixable)
+
+"""
+from .Payment import Payment
+from .Attempt import Attempt, AttemptStatus
+from .UncertaintyNetwork import UncertaintyNetwork
+from .OracleLightningNetwork import OracleLightningNetwork
+from math import log2 as log
+
+import time
+from typing import List
+import networkx as nx
+
+import logging
+from logging import Logger
+import sys
+
+# logger = logging.getLogger(__name__)
+logger: Logger = logging.getLogger()
+# formatter = logging.Formatter('%(asctime)s.%(msecs)03d | %(levelname)s | %(message)s', datefmt='%H:%M:%S')
+stdout_handler = logging.StreamHandler(sys.stdout)
+stdout_handler.setLevel(logging.INFO)
+# stdout_handler.setFormatter(formatter)
+file_handler = logging.FileHandler('redundant_pickhardt_pay.log', mode='a')
+file_handler.setLevel(logging.DEBUG)
+# file_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+
+
+class DijkstraOverPayment(Payment):
+
+    def __init__(self, uncertainty_network: UncertaintyNetwork, oracle_network: OracleLightningNetwork, sender,
+                 receiver, total_amount: int, mu: int, base: int):
+        """Constructor method
+        """
+        self._successful = False
+        self._ppm = None
+        self._start_time = time.time()
+        self._end_time = None
+        self._sender = sender
+        self._receiver = receiver
+        self._total_amount = total_amount
+        self._residual_amount = total_amount
+        self._attempts = list()
+        self._uncertainty_network = uncertainty_network
+        self._oracle_network = oracle_network
+        self._prepare_integer_indices_for_nodes()
+        self._mu = mu
+        self._base = base
+        self._pickhardt_payment_rounds = 0
+        self._uncertainty_network_entropy = self._uncertainty_network.entropy()
+
+    def _make_flow_network(self, f=1):
+        self._residual_network = nx.MultiDiGraph()
+        for s, d, channel in self._uncertainty_network.network.edges(data="channel"):
+            c = channel.conditional_capacity
+
+            if f < channel.capacity + 1:
+                self._residual_network.add_edge(
+                    s, d, cost=(channel.ppm+100)/(channel.conditional_capacity), key=channel.short_channel_id, channel=channel)
+
+    def _next_hop(self, path):
+        """
+        generator to iterate through edges indexed by node id of paths
+
+        The path is a list of node ids. Each call returns a tuple src, dest of an edge in the path
+        """
+        for i in range(1, len(path)):
+            src = path[i - 1]
+            dest = path[i]
+            yield src, dest
+
+    def _make_channel_path(self, path: List[str]) -> object:
+        """
+        network x returns a path as a list of node_ids. However, we need a list of `UncertaintyChannels`
+        Since the graph has parallel edges it is quite some work to get the actual channels that the
+        min cost flow solver produced
+        """
+        channel_path = []
+        for src, dest in self._next_hop(path):
+            w = 2 ** 63
+            c = None
+            flow = 0
+            for sid in self._residual_network[src][dest].keys():
+                if self._residual_network[src][dest][sid]["cost"] < w:
+                    w = self._residual_network[src][dest][sid]["cost"]
+                    c = self._residual_network[src][dest][sid]["channel"]
+            channel_path.append(c)
+        return channel_path
+
+    def _generate_candidate_paths(self):
+        logger.debug("Amount to send: {}".format(self._total_amount))
+        # FIXME: remove magic number
+        reliability_buffer = 1.3
+        # FIXME: remove magic number
+        min_probability = 0.8
+        # First we prepare the min cost flow by getting arcs from the uncertainty network
+        self._make_flow_network()
+        self._start_time = time.time()
+        logger.debug("run the dijkstra overpayer...")
+        ev = 0
+        cnt = 0
+        total_amount = 0
+        attempts = []
+        while True:
+            path = nx.shortest_path(
+                self._residual_network, self._sender, self._receiver, weight="cost")
+            channel_path = self._make_channel_path(path)
+
+            min_conditional_capacity = min(
+                chan.conditional_capacity for chan in channel_path)
+            p = min_probability**(1.0/len(path))
+            amt = int(min_conditional_capacity - p * min_conditional_capacity)
+            total_amount += amt
+            channel_path = self._make_channel_path(path)
+
+            for channel in channel_path:
+                # FIXME: remove magic number
+                self._residual_network[channel.src][channel.dest][channel.short_channel_id]["cost"] *= 1.2
+
+            attempt = Attempt(channel_path, amt)
+            attempts.append(attempt)
+
+            p = attempt.probability
+            ev += int(p*amt)
+            logger.info("Path #{:2} with {:2} hops and min conditional capacity of {:10} sats alloc: {:10} sats".format(
+                cnt+1, len(path), min_conditional_capacity, int(amt)))
+
+            cnt += 1
+            if ev > self.total_amount * reliability_buffer:
+                break
+
+        print("to sent {} sats we sent {} onions with a total liquidity of {} and expect to deliver: {:5.3f}".format(
+            self.total_amount, cnt, total_amount, ev))
+        print("This is an overpayment of {:4.2f}\n\n".format(total_amount/ev))
+
+        self._end_time = time.time()
+        self.register_candidate_paths(attempts)
+        return self._end_time - self._start_time
+
+    def get_summary(self):
+        logger.info("SUMMARY:")
+        logger.info("========")
+        settled = sum(a.amount for a in self.filter_attempts(
+            AttemptStatus.SETTLED))
+        failed = sum(a.amount for a in self.filter_attempts(
+            AttemptStatus.FAILED))
+        logger.info(
+            "Rounds of MCF-computations:\t{:3}".format(self.pickhardt_payment_rounds))
+        logger.info("Settled {} sats and failed {} sats. fraction of settled liquidity {:4.2f}%".format(
+            settled, failed, (100.0*settled)/(settled+failed)))
+        # logger.info(
+        #    "Rounds of MEVF-computations:\t{:3}".format(self.pickhardt_payment_rounds))
+        logger.info("Number of attempts made:\t\t{:3}".format(
+            len(self.attempts)))
+        logger.info("Number of failed attempts:\t{:3}".format(
+            len(list(self.filter_attempts(AttemptStatus.FAILED)))))
+        logger.info("Failure rate: {:4.2f}% ".format(
+            len(list(self.filter_attempts(AttemptStatus.FAILED))) * 100. / len(self.attempts)))
+        logger.info("total Payment lifetime (including inefficient memory management): {:4.3f} sec".format(
+            self.life_time))
+        logger.info("Learnt entropy: {:5.2f} bits".format(
+            self.uncertainty_network_entropy_delta))
+        logger.info("fee for settlement of delivery: {:8.3f} sat --> {} ppm".format(
+            self.settlement_fees / 1000, int(self.settlement_fees * 1000 / self.total_amount)))
+        logger.info("used mu: %s", self._mu)
+        logger.info("Payment was successful: %s", self.successful)

--- a/pickhardtpayments/SyncSimulatedPaymentSession.py
+++ b/pickhardtpayments/SyncSimulatedPaymentSession.py
@@ -4,16 +4,19 @@ SyncSimulatedPaymentSession.py
 The core module of the pickhardt payment project.
 An example payment is executed and statistics are run.
 """
-from .Payment import Payment, MCFSolverError
+from .Payment import Payment
 from .UncertaintyNetwork import UncertaintyNetwork
 from .OracleLightningNetwork import OracleLightningNetwork
+from .DijkstraOverPayment import DijkstraOverPayment
+#from .RedundantOverPayment import RedundantOverPayment
 
 import logging
 import sys
 
 session_logger = logging.getLogger()
 session_logger.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s.%(msecs)03d | %(levelname)s | %(message)s', datefmt='%H:%M:%S')
+formatter = logging.Formatter(
+    '%(asctime)s.%(msecs)03d | %(levelname)s | %(message)s', datefmt='%H:%M:%S')
 stdout_handler = logging.StreamHandler(sys.stdout)
 stdout_handler.setLevel(logging.INFO)
 stdout_handler.setFormatter(formatter)
@@ -56,8 +59,7 @@ class SyncSimulatedPaymentSession:
 
     def forget_information(self):
         """
-        Forgets all the information in the UncertaintyNetwork the PaymentSession
-        Resets minimum liquidity to 0, max liquidity to capacity and in_flights to 0.
+        forgets all the information in the UncertaintyNetwork that is a member of the PaymentSession
         """
         self._uncertainty_network.reset_uncertainty_network()
 
@@ -68,102 +70,77 @@ class SyncSimulatedPaymentSession:
         self._uncertainty_network.activate_network_wide_uncertainty_reduction(
             n, self._oracle_network)
 
-    def pickhardt_pay(self, src, dest, amt=1, mu=1, base=DEFAULT_BASE_THRESHOLD):
+    def pickhardt_pay(self, src, dest, amt=1, mu=1, base=DEFAULT_BASE_THRESHOLD, redundant_over_payment=False):
         """
         Conducts one payment with the pickhardt payment methodology.
-        Tries up to 15 rounds or until payment probability of an attempt is less than 5%
 
-        :sub_payment.initiate(): starts the first round and calls the solver to get paths. For each path the attempt is
-        registered as planned and the amount is registered in the uncertainty network as in_flight.
-        :OracleLightningNetwork.send_onion(): is called on the Attempts of this first round and with this the attempts
-        are then tested against the OracleNetwork. Every failed attempt from send_onion is then updated as
+        conduct one experiment! might need to call oracle.reset_uncertainty_network() first
+        I could not put it here as some experiments require sharing of liquidity information
+
+        sub_payment.initiate() starts the first round with calling the solver to get paths. For each path the attempt is
+        registered as planned and the amount is registered in the uncertainty network as in_flight (better name can be
+        determined). On the Attempts of this first round send_onion() is called and with this the attempts are then
+        tested against the OracleNetwork. Every failed attempt from send_onion is then updated as
         AttemptStatus.FAILED and the in_flight amounts are removed from the UncertaintyNetwork.
-        For every successful call of send_onion the amount is registered in the OracleNetwork as inflight and the
+        For every successful  call of send_onion the amount is registered in the OracleNetwork as inflight and the
         AttemptStatus is set to AttemptStatus.INFLIGHT. The amounts have been allocated in the UncertaintyNetwork
         already, so no change is necessary here.
         If onions failed, the next round is started for the remaining amount.
-        `evaluate attempts` sends statistics on the Attempt to the logs.
-        `register_sub_payment` collects and adds all Attempts - failed and inflight - to the original Payment.
 
         After the total amount has been allocated on the OracleNetwork, Payment.finalize() is called. This then
         reflects the arrival of all payments at the receiver, who then passes the preimage to unlock the
         HTLCs/inflight amounts. For all Attempts of the Payment with AttemptStatus.INFLIGHT the balances of the nodes
-        are updated in the OracleNetwork on both channels.
-        The AttemptStatus is consequently set to SETTLED, which triggers the update of the channels in the
-        UncertaintyNetwork.
+        are updated in the OracleNetwork on both channels (a refactoring of the OracleNetwork can still be
+        considered) and also on the Uncertainty Network. The AttemptStatus is consequently set to SETTLED.
 
-        amt=1, mu=1, base=DEFAULT_BASE_THRESHOLD, loglevel="info"
-        :param src: node id of the sending node
-        :type: str
-        :param dest: node id of the receiving node
-        :type: str
-        :param amt: amount in satoshi to be sent
-        :type: int
-        :param mu: controls the balance between uncertainty cost and fees in the solver
-        :type: int
-        :param base: eliminates all channels with a base fee lower than `base`
-        :type: int
         """
         session_logger.info('*** new pickhardt payment ***')
-        probability_too_low = False
 
         # Initialise Payment
-        payment = Payment(self.uncertainty_network, self.oracle_network, src, dest, amt, mu, base)
+        payment = None
+        if redundant_over_payment is True:
+            session_logger.info(
+                "using redundant overpayments and max expected value flows")
+            payment = DijkstraOverPayment(
+                self.uncertainty_network, self.oracle_network, src, dest, amt, mu, base)
+        else:
+            payment = Payment(self.uncertainty_network,
+                              self.oracle_network, src, dest, amt, mu, base)
 
         # This is the main payment loop. It is currently blocking and synchronous but may be
         # implemented in a concurrent way. Also, we stop after 10 rounds which is pretty arbitrary
         # a better stop criteria would be if we compute infeasible flows or if the probabilities
         # are too low or residual amounts decrease to slowly
         # TODO add 'expected value' to break condition for loop
-        while payment.residual_amount > 0 and payment.pickhardt_payment_rounds <= 15 and not probability_too_low:
-            payment.increment_pickhardt_payment_rounds()
-            sub_payment = Payment(self.uncertainty_network, self.oracle_network, payment.sender, payment.receiver,
-                                  payment.residual_amount, mu, base)
+        while payment.residual_amount > 0 and payment.pickhardt_payment_rounds <= 15:
+            if redundant_over_payment is False:
+                sub_payment = Payment(self.uncertainty_network, self.oracle_network, payment.sender, payment.receiver,
+                                      payment.residual_amount, mu, base)
+            else:
+                sub_payment = DijkstraOverPayment(self.uncertainty_network, self.oracle_network, payment.sender, payment.receiver,
+                                                  payment.residual_amount, mu, base)
 
             # transfer to a min cost flow problem and run the solver. Attempts for payment are generated.
-            try:
-                sub_payment.initiate()
-            except MCFSolverError as err:
-                logging.error(err)
-                logging.error("Payment failed. No path found.")
-                return -1, 0
+            sub_payment.initiate()
 
             # Try to send amounts in attempts and registers if success or not
             # update our information regarding the in_flights in the UncertaintyNetwork and OracleNetwork
             sub_payment.attempt_payments()
 
             # run some simple statistics and depict them
-            sub_payment.evaluate_attempts()
-            if sub_payment.attempts[-1].probability < 0.05:
-                probability_too_low = True
-                logging.warning("probability in last attempt too low")
+            sub_payment.evaluate_attempts(payment)
 
             # add attempts of sub_payment to payment
             payment.register_sub_payment(sub_payment)
 
         # When residual amount is 0 then settle payment.
-        if payment.residual_amount == 0:
-            # for attempt in payment.attempts:
-            #    logging.debug("___")
-            #    for channel in attempt.path:
-            #        logging.debug("- " + channel.src[0:4] + " to " + channel.dest[0:4] + ", " + str(attempt.amount))
+        if payment.residual_amount <= 10:
+            # TODO: potentially we wish to aboard and not execute
             payment.execute()
-            logging.debug("Payment successful.")
         else:
-            session_logger.error("Payment failed!")
-            session_logger.info("residual amount: {:>10,} sats".format(payment.residual_amount))
-
-        # cleanup of in_flights in Networks
-        for attempt in payment.attempts:
-            for uncertainty_channel in attempt.path:
-                uncertainty_channel.in_flight = 0
-                self.oracle_network.get_channel(uncertainty_channel.src, uncertainty_channel.dest,
-                                                uncertainty_channel.short_channel_id).in_flight = 0
+            session_logger.info("Payment failed!")
+            session_logger.info("residual amount: %s sats",
+                                payment.residual_amount)
 
         # Final Stats
         payment.get_summary()
-
-        if payment.residual_amount:
-            return payment.residual_amount, 0
-        else:
-            return 0, payment.settlement_fees


### PR DESCRIPTION
This PR introduces 2 things: 

1. A new technique to generate an MPP split in a greedy way that is both cheap and aims for reliability. 
2. A potential answer to the question of how to plan and design a redundant overpayment which has been shown to be an effective technique to increase reliability. 

## WARNING!!! very experimental work in progress! Only use with caution and wait for the proper release

The `DijkstraOverPayment` class aims to find Dijkstra paths in a pragmatic way for redundant overpayments. 
In particular it is a proof of concept to generate an MPP-Split in an ad hoc way that seems to be more 
resonable than existing splitters which either do devide an conquorer or split to a certain amount or split
to a predefined number of parts. 
This splitter finds low cost paths and greedly allocates as many sats as long as the reliability stays abvove a threshold

The main ideas are the following: 

## With respect to the cost function for candidate selection:

We use dijkstra to compute candidate paths as shortest paths with respect to our cost function

1.) Use a cost function for a unit that is the combination of `linearized routing cost` and `linearized uncertainty cost`
2.) smooth the routing cost (currently laplace smoothing with `+100`. The exact value needs to be found
3.) `cost = (ppm + 100) * 1/capacity`
4.) after a path is planned increase cost of each edge with a multiplier

## with respect to allocation of funds to paths

The cost function favors paths with low routing costs thus the only question is how many sats to allocate? 
The following idea shall be used for motivation: 

* We want each path to have a success probability of at least `x%`
* Thus let `l` be the length of the planned path and `c` be the capacity of the smallest channel.
* Then `s = (c+1-a)/(c+1)` is the success probability for the allocated amount `a` 
* We require `s >= x ** (1/l)` which means the path has a probability of at least `x`
* For now we ignore prior knowledge and believe (Thus one reason for this to be WIP)
* knowing `s` at equality we solve for `a` --> `a = (c+1) - s*(c+1) = (c+1)*(1-s)`
* we allocate `a` sats to the candidate path

## Number of generated / planned candidate paths

* for each path we compute it's expected value of delivered sats as its actual success probability mutitplied by the allocated sats
* As the expected value is linear we generate paths until the sum of the EVs is larger than our target total EV
* the target total EV is the amount we wish to deliver (e.g. given by an invoice) multiplied with a reliability factor (>= 1.0)


## known short commings:
* subset of generated paths does not add to payment amount
* base fee is ignored
* learnt knowledge is ignored
* magic numbers are hard coded and not configureable (requires refactoring of the lib)
* output / api fits more to MCF approach
* handeling of edge cases
* assumes uniform distribution (which is actually easily fixable)
 